### PR TITLE
Add logging for image generation

### DIFF
--- a/routers/images.py
+++ b/routers/images.py
@@ -54,10 +54,15 @@ async def upscale_image(url: str) -> str:
     import replicate
     client = replicate.Client(api_token=token)
     try:
+        print("Replicate upscale input URL:", url)
         output = await run_in_threadpool(client.run, "cjwbw/real-esrgan", input={"image": url})
+        print("Replicate upscale raw response:", output)
         if isinstance(output, list):
-            return output[-1]
-        return str(output)
+            result = output[-1]
+        else:
+            result = str(output)
+        print("Replicate upscale result URL:", result)
+        return result
     except Exception as e:
         print(f"Upscale error: {e}")
         return url
@@ -81,9 +86,21 @@ async def generate_images(req: ImageGenerationRequest, current_user: models.User
         try:
             for i in range(req.count):
                 seed = base_seed if req.deference == 1 else base_seed + i
-                res = await openai_client.images.generate(model="dall-e-3", prompt=optimized, n=1, size="1024x1024", seed=seed)
-                urls.append(res.data[0].url)
+                params = {
+                    "model": "dall-e-3",
+                    "prompt": optimized,
+                    "n": 1,
+                    "size": "1024x1024",
+                    "seed": seed,
+                }
+                print("DALL·E request params:", params)
+                res = await openai_client.images.generate(**params)
+                print("DALL·E raw response:", res)
+                url = res.data[0].url
+                print("DALL·E image URL:", url)
+                urls.append(url)
         except Exception as e:
+            print("DALL·E error:", e)
             raise HTTPException(status_code=500, detail=f"OpenAI image error: {e}")
     else:
         try:
@@ -98,21 +115,24 @@ async def generate_images(req: ImageGenerationRequest, current_user: models.User
         negative = None if req.allow_text else "text, watermark, letters, logo"
         for i in range(req.count):
             seed = base_seed if req.deference == 1 else base_seed + i
-            answer = await run_in_threadpool(
-                stability.generate,
-                prompt=optimized,
-                steps=30,
-                seed=seed,
-                cfg_scale=cfg_scale,
-                negative_prompt=negative,
-            )
+            params = {
+                "prompt": optimized,
+                "steps": 30,
+                "seed": seed,
+                "cfg_scale": cfg_scale,
+                "negative_prompt": negative,
+            }
+            print("Stable Diffusion request params:", params)
+            answer = await run_in_threadpool(stability.generate, **params)
             for resp in answer:
                 for art in resp.artifacts:
                     if art.finish_reason == generation.FILTER:
                         continue
                     if art.type == generation.ARTIFACT_IMAGE:
                         b64 = base64.b64encode(art.binary).decode()
-                        urls.append(f"data:image/png;base64,{b64}")
+                        url = f"data:image/png;base64,{b64}"
+                        print("Stable Diffusion image URL:", url)
+                        urls.append(url)
     upscaled = []
     for u in urls:
         upscaled.append(await upscale_image(u))

--- a/sdxl_ping.py
+++ b/sdxl_ping.py
@@ -5,8 +5,13 @@ os.environ["REPLICATE_API_TOKEN"] = "r8_********************************"
 
 MODEL = "stability-ai/sdxl@7762fd07cf82c948538e41f63f77d685e02b063e37e496e96eefd46c929f9bdc"
 
+prompt = "red and blue test"
+params = {"prompt": prompt}
+print("Replicate prompt:", prompt)
+print("Replicate request params:", params)
 try:
-    url = replicate.Client().run(MODEL, input={"prompt": "red and blue test"})
+    url = replicate.Client().run(MODEL, input=params)
+    print("Replicate raw response:", url)
     print("✅ 生成URL:", url)
 except Exception as e:
     print("❌ ERROR:", e.__class__.__name__, "-", e)

--- a/services/profile_image.py
+++ b/services/profile_image.py
@@ -11,34 +11,44 @@ logger = logging.getLogger(__name__)
 
 
 async def _gen_with_dalle(prompt: str) -> bytes:
-    resp = await openai_client.images.generate(
-        model="dall-e-3",
-        prompt=prompt,
-        size="1024x1024",
-        n=1,
-        quality="standard",
-        style="vivid",
-    )
+    print("DALL·E prompt:", prompt)
+    params = {
+        "model": "dall-e-3",
+        "prompt": prompt,
+        "size": "1024x1024",
+        "n": 1,
+        "quality": "standard",
+        "style": "vivid",
+    }
+    print("DALL·E request params:", params)
+    resp = await openai_client.images.generate(**params)
+    print("DALL·E raw response:", resp)
     url = resp.data[0].url
+    print("DALL·E image URL:", url)
     async with httpx.AsyncClient() as cx:
-        return (await cx.get(url)).content
+        content = (await cx.get(url)).content
+    return content
 
 
 async def _gen_with_sdxl(prompt: str, neg: str) -> bytes:
+    print("SDXL prompt:", prompt)
+    print("SDXL negative_prompt:", neg)
     def _run():
-        return sd_client.run(
-            f"{MODEL_ID}:main",
-            input={
-                "prompt": prompt,
-                "negative_prompt": neg,
-                "width": 1024,
-                "height": 1024,
-            },
-        )
+        params = {
+            "prompt": prompt,
+            "negative_prompt": neg,
+            "width": 1024,
+            "height": 1024,
+        }
+        print("SDXL request params:", params)
+        return sd_client.run(f"{MODEL_ID}:main", input=params)
 
     url = await asyncio.to_thread(_run)
+    print("SDXL image URL:", url)
     async with httpx.AsyncClient() as cx:
-        return (await cx.get(url)).content
+        content = (await cx.get(url)).content
+    print("SDXL image bytes:", len(content))
+    return content
 
 
 async def generate_and_save(c1_hex: str, c2_hex: str, gender: str, user_id: int) -> None:
@@ -55,13 +65,16 @@ async def generate_and_save(c1_hex: str, c2_hex: str, gender: str, user_id: int)
         img_bytes = await _gen_with_dalle(prompt)
     except Exception as e:
         logger.warning(f"DALL·E failed, fallback to SDXL: {e}")
+        print("DALL·E error:", e)
         try:
             img_bytes = await _gen_with_sdxl(prompt, neg)
         except Exception as e2:
             logger.error(f"SDXL also failed: {e2}")
+            print("SDXL error:", e2)
             Path("static/profile").mkdir(exist_ok=True, parents=True)
             shutil.copy("Pic/デフォルト.png", f"static/profile/{user_id}.png")
             return
 
     Path("static/profile").mkdir(exist_ok=True, parents=True)
     (Path("static/profile") / f"{user_id}.png").write_bytes(img_bytes)
+    print("Saved image for user", user_id)


### PR DESCRIPTION
## Summary
- log prompts, parameters, responses and errors when generating images with DALL·E, SDXL or Replicate
- add similar logging to the image generation API endpoint and local SDXL tester script

## Testing
- `pytest -q` *(fails: `pytest` not found)*