### PR TITLE
Implement chat loading status

### DIFF
--- a/alembic/versions/add_session_status.py
+++ b/alembic/versions/add_session_status.py
@@ -1,0 +1,19 @@
+"""add status column to chat_sessions"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'add_session_status'
+down_revision: Union[str, None] = 'add_profile_fields'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('chat_sessions') as batch_op:
+        batch_op.add_column(sa.Column('status', sa.String(), server_default='complete', nullable=False))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('chat_sessions') as batch_op:
+        batch_op.drop_column('status')

--- a/collaboration_ai_ui.html
+++ b/collaboration_ai_ui.html
@@ -1208,6 +1208,7 @@
                     const sessionElementContainer = document.createElement('div'); // ★★★ 各セッションのコンテナ ★★★
                     sessionElementContainer.className = 'session-element flex items-center w-full hover:bg-teal-50 rounded-md group';
                     sessionElementContainer.setAttribute('data-session-id', session.id);
+                    sessionElementContainer.setAttribute('data-status', session.status || 'complete');
 
                     sessionElementContainer.draggable = true;
                     sessionElementContainer.addEventListener('dragstart', (e) => {
@@ -1234,6 +1235,11 @@
                         <span class="session-title-text flex-grow truncate" title="${session.title || ''}">${titleText}</span>
                         <span class="text-xs text-gray-400 flex-shrink-0 ml-1">${formattedDate}</span>
                     `;
+                    if (session.status && session.status !== 'complete') {
+                        const sp = document.createElement('span');
+                        sp.className = 'session-loading-spinner';
+                        sessionButton.appendChild(sp);
+                    }
                     sessionButton.addEventListener('click', () => handleSessionSelection(session.id));
 
                     // アクションボタンコンテナ
@@ -1462,6 +1468,12 @@ async function handleSessionSelection(sessionId) {
             newlySelectedButton.classList.add('session-button-active');
         }
 
+        const statusContainer = chatSessionListDiv.querySelector(`.session-element[data-session-id="${sessionId}"]`);
+        if (statusContainer && statusContainer.dataset.status && statusContainer.dataset.status !== 'complete') {
+            if (chatMessagesContainer) chatMessagesContainer.innerHTML = '';
+            displayMessage('回答生成中...', 'system');
+        }
+
 
         currentSessionId = sessionId;
         if (chatMessagesContainer) chatMessagesContainer.innerHTML = ''; // メッセージ表示エリアをクリア
@@ -1588,17 +1600,26 @@ async function handleSessionSelection(sessionId) {
             displayMessage(promptValue, 'user'); // ユーザーのメッセージを先に表示
             promptTextarea.value = ''; // 入力欄をクリア
 
+            if (currentSessionId === null) {
+                try {
+                    const provisional = promptValue.split(/\n/)[0].substring(0, 20) || '新しいチャット';
+                    const createRes = await makeAuthenticatedRequest(API_ENDPOINT_CHAT_SESSIONS, {
+                        method: 'POST',
+                        body: JSON.stringify({ title: provisional, status: 'loading' })
+                    });
+                    if (createRes.ok) {
+                        const newS = await createRes.json();
+                        currentSessionId = newS.id;
+                        await loadChatSessions();
+                    }
+                } catch(e) { console.error('session create error', e); }
+            }
+
             const requestSessionId = currentSessionId;
             const targetKey = requestSessionId !== null ? String(requestSessionId) : 'new';
             if (sessionLoading[targetKey]) { alert('このチャットは応答待ちです。'); return; }
             sessionLoading[targetKey] = true;
             const container = document.querySelector(`.session-element[data-session-id="${requestSessionId}"]`);
-            let spinnerEl = null;
-            if (container) {
-                spinnerEl = document.createElement('span');
-                spinnerEl.className = 'session-loading-spinner';
-                container.appendChild(spinnerEl);
-            }
             if (currentSessionId === requestSessionId && requestSessionId !== null) {
                 loadingIndicator.classList.remove('hidden');
             }
@@ -1690,7 +1711,6 @@ async function handleSessionSelection(sessionId) {
                 displayMessage(`リクエスト処理中にエラーが発生しました: ${error.message}`, 'ai', 'SystemError');
             } finally {
                 sessionLoading[targetKey] = false;
-                if (spinnerEl && spinnerEl.parentNode) spinnerEl.remove();
                 if (requestSessionId !== null && currentSessionId === requestSessionId) {
                     loadingIndicator.classList.add('hidden');
                 }

--- a/main.py
+++ b/main.py
@@ -593,7 +593,7 @@ async def collaborative_answer_mode_endpoint(
             potential_title = "新しいチャット"  # プロンプトが全くない場合
         # ★★★ ここまで ★★★
 
-        active_session = models.ChatSession(user_id=current_user.id, title=potential_title)
+        active_session = models.ChatSession(user_id=current_user.id, title=potential_title, status='loading')
         db.add(active_session)
         db.commit()  # 先にセッションをコミットしてIDを確定させる
         db.refresh(active_session)
@@ -621,7 +621,7 @@ async def collaborative_answer_mode_endpoint(
         session_title = (
             original_prompt[:70].strip() + "..." if len(original_prompt) > 70 else original_prompt.strip()
         )
-        active_session = models.ChatSession(user_id=current_user.id, title=session_title)
+        active_session = models.ChatSession(user_id=current_user.id, title=session_title, status='loading')
         print(
             f"警告: active_sessionが未作成だったため、新規作成します。Title='{active_session.title}'"
         )
@@ -644,6 +644,7 @@ async def collaborative_answer_mode_endpoint(
 
     db.add(user_message_db)
     active_session.updated_at = func.now()  # セッションの最終更新日時を更新
+    active_session.status = 'loading'
     db.add(active_session)  # 明示的に追加して更新をトラッキング
     db.commit()
     db.refresh(user_message_db)
@@ -764,6 +765,7 @@ async def collaborative_answer_mode_endpoint(
                 )
                 db.add(ai_message_db)
                 active_session.updated_at = func.now() # セッション最終更新
+                active_session.status = 'complete'
                 db.add(active_session) # 明示的なadd
                 db.commit()
                 db.refresh(ai_message_db)
@@ -901,6 +903,7 @@ async def run_super_search_mode_flow(
                     )
                     db.add(ai_message_db)
                     active_session.updated_at = func.now()
+                    active_session.status = 'complete'
                     db.commit()
                     db.refresh(ai_message_db)
                     db.refresh(active_session)

--- a/models.py
+++ b/models.py
@@ -58,6 +58,7 @@ class ChatSession(Base):
     tags = Column(String, nullable=True)
     mode = Column(String, nullable=False, server_default="chat")
     is_complete = Column(Boolean, nullable=False, server_default=text('1'))
+    status = Column(String, nullable=False, server_default="complete")
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()

--- a/routers/chat.py
+++ b/routers/chat.py
@@ -40,6 +40,7 @@ async def create_chat_session(
         tags=chat_session_in.tags if hasattr(chat_session_in, 'tags') else None,
         mode='chat',
         is_complete=True,
+        status=chat_session_in.status if hasattr(chat_session_in, 'status') else 'complete',
     )
     db.add(new_session)
     db.commit()
@@ -225,6 +226,7 @@ async def clone_chat_session(
         folder_id=clone_data.folder_id,
         mode=original.mode,
         is_complete=original.is_complete,
+        status='complete',
     )
     db.add(new_session)
     db.commit()

--- a/schemas.py
+++ b/schemas.py
@@ -58,6 +58,7 @@ class ChatSessionBase(BaseModel):
     tags: Optional[str] = None
     mode: str = "chat"
     is_complete: bool = True
+    status: Optional[str] = "complete"
 
 class ChatSessionCreate(ChatSessionBase):
     pass
@@ -79,6 +80,7 @@ class ChatSessionResponse(ChatSessionBase):
     updated_at: Optional[datetime] = None
     mode: str
     is_complete: bool
+    status: str
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
## Summary
- add `status` column to `ChatSession` and expose it via schemas
- create Alembic migration for the new column
- mark sessions `loading` while generating and `complete` after
- update chat list UI to show spinner for loading sessions
- create new session before sending first prompt so history updates immediately

## Testing
- `pytest -q` *(fails: command not found)*