### PR TITLE
Implement instant new chat UI

### DIFF
--- a/collaboration_ai_ui.html
+++ b/collaboration_ai_ui.html
@@ -650,6 +650,7 @@
     let currentSessionId = null;
     let currentFolderId = 0; // 0: 全て, -1: 未分類, その他: folder id
     const sessionLoading = {}; // セッションごとの処理中状態
+    const pendingSessionPromises = {}; // 新規作成中セッションのPromise管理
     let currentUserProfileImage = null;
     let foldersCache = [];
     let previousAiMode = aiModeSelect.value;
@@ -1455,6 +1456,17 @@ async function handleSessionSelection(sessionId) {
         }
         sessionId = parseInt(sessionId); // 数値に変換
 
+        if (sessionId < 0) { // 仮セッションはサーバー問い合わせを行わない
+            currentSessionId = sessionId;
+            if (chatMessagesContainer) chatMessagesContainer.innerHTML = '';
+            displayMessage('新しいチャットが開始されました。メッセージをどうぞ。', 'system');
+            const allSessionElements = chatSessionListDiv.querySelectorAll('.session-element > button');
+            allSessionElements.forEach(btn => btn.classList.remove('session-button-active'));
+            const newlySelectedButton = chatSessionListDiv.querySelector(`.session-element[data-session-id="${sessionId}"] > button`);
+            if (newlySelectedButton) newlySelectedButton.classList.add('session-button-active');
+            return;
+        }
+
         // 既に選択されているセッションで、かつメッセージが表示されていれば何もしない
         if (currentSessionId === sessionId && chatMessagesContainer.childElementCount > 1 && !chatMessagesContainer.innerHTML.includes('読込中...')) {
             return;
@@ -1503,12 +1515,23 @@ async function handleSessionSelection(sessionId) {
         }
     }
 
-    function highlightMessage(messageId) {
+function highlightMessage(messageId) {
         const target = document.querySelector(`[data-message-id="${messageId}"]`);
         if (target) {
             target.classList.add('bg-yellow-100');
             target.scrollIntoView({ behavior: 'smooth', block: 'center' });
             setTimeout(() => target.classList.remove('bg-yellow-100'), 2000);
+        }
+    }
+
+    async function ensureSessionReady() {
+        if (currentSessionId !== null && currentSessionId < 0 && pendingSessionPromises[currentSessionId]) {
+            const newId = await pendingSessionPromises[currentSessionId];
+            if (newId) {
+                currentSessionId = newId;
+            } else {
+                currentSessionId = null;
+            }
         }
     }
 
@@ -1599,6 +1622,8 @@ async function handleSessionSelection(sessionId) {
             const selectedMode = aiModeSelect.value;
             displayMessage(promptValue, 'user'); // ユーザーのメッセージを先に表示
             promptTextarea.value = ''; // 入力欄をクリア
+
+            await ensureSessionReady();
 
             if (currentSessionId === null) {
                 try {
@@ -1840,35 +1865,49 @@ async function handleSessionSelection(sessionId) {
         if (newChatButton) {
             newChatButton.addEventListener('click', async () => {
                 if (!getToken()) { alert('この機能を利用するにはログインが必要です。'); return; }
-                currentSessionId = null; // 新規チャットなので現在のセッションIDをクリア
-                if (chatMessagesContainer) chatMessagesContainer.innerHTML = ''; // メッセージ表示エリアをクリア
+
+                const tempId = -Date.now();
+                currentSessionId = tempId;
+                if (chatMessagesContainer) chatMessagesContainer.innerHTML = '';
                 displayMessage('新しいチャットが開始されました。メッセージをどうぞ。', 'system');
 
-                // チャットリストのアクティブ表示を解除
                 const activeSessionButton = chatSessionListDiv.querySelector('.session-button-active');
                 if (activeSessionButton) activeSessionButton.classList.remove('session-button-active');
 
-                // 新規チャットセッションをバックエンドに作成するリクエスト (タイトルは空で良い)
-                // (この部分は、最初のプロンプト送信時に /collaborative_answer_v2 で
-                //  session_id=null として送ればバックエンドで新規作成されるので、
-                //  ここでは必ずしもAPIを叩く必要はないかもしれない。
-                //  ただし、明示的に空のセッションを作りたい場合は以下のようにする)
-                /*
-                try {
-                    const response = await makeAuthenticatedRequest(API_ENDPOINT_CHAT_SESSIONS, {
-                        method: 'POST',
-                        body: JSON.stringify({ title: "新しいチャット" }) // 初期タイトル
-                    });
-                    if (!response.ok) throw new Error('新規チャットの作成に失敗しました。');
-                    const newSession = await response.json();
-                    currentSessionId = newSession.id;
-                    await loadChatSessions(); // リストを更新して新しいセッションを表示
-                    handleSessionSelection(newSession.id); // 新しいセッションを選択状態にする
-                } catch (error) {
-                    console.error("新規チャット作成エラー:", error);
-                    alert(error.message);
-                }
-                */
+                const sessionElementContainer = document.createElement('div');
+                sessionElementContainer.className = 'session-element flex items-center w-full hover:bg-teal-50 rounded-md group';
+                sessionElementContainer.setAttribute('data-session-id', tempId);
+                sessionElementContainer.setAttribute('data-status', 'creating');
+
+                const sessionButton = document.createElement('button');
+                sessionButton.className = 'flex items-center flex-grow px-3 py-2 text-sm text-left text-gray-700 focus:outline-none transition-colors duration-150 ease-in-out session-button-active';
+                sessionButton.innerHTML = `<svg class="w-4 h-4 mr-2 flex-shrink-0 text-gray-400 group-hover:text-teal-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8h2a2 2 0 012 2v6a2 2 0 01-2 2h-2v4l-4-4H9a1.994 1.994 0 01-1.414-.586m0 0L11 14h4a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2v4l.586-.586z"></path></svg><span class="session-title-text flex-grow truncate" title="新しいチャット">新しいチャット</span><span class="text-xs text-gray-400 flex-shrink-0 ml-1">--:--</span><span class="session-loading-spinner"></span>`;
+                sessionButton.addEventListener('click', () => handleSessionSelection(tempId));
+                sessionElementContainer.appendChild(sessionButton);
+                chatSessionListDiv.prepend(sessionElementContainer);
+
+                pendingSessionPromises[tempId] = (async () => {
+                    try {
+                        const response = await makeAuthenticatedRequest(API_ENDPOINT_CHAT_SESSIONS, {
+                            method: 'POST',
+                            body: JSON.stringify({ title: '新しいチャット' })
+                        });
+                        if (!response.ok) throw new Error('新規チャットの作成に失敗しました。');
+                        const newSession = await response.json();
+                        if (currentSessionId === tempId) currentSessionId = newSession.id;
+                        await loadChatSessions();
+                        handleSessionSelection(newSession.id);
+                        return newSession.id;
+                    } catch (error) {
+                        console.error('新規チャット作成エラー', error);
+                        if (currentSessionId === tempId) currentSessionId = null;
+                        if (sessionElementContainer.parentElement) sessionElementContainer.remove();
+                        displayMessage('チャット作成に失敗しました', 'system');
+                        return null;
+                    } finally {
+                        delete pendingSessionPromises[tempId];
+                    }
+                })();
             });
         }
         // Enterキーでの送信


### PR DESCRIPTION
## Summary
- add `pendingSessionPromises` to track async chat creation
- allow `handleSessionSelection` to handle temporary sessions
- create temporary chat instantly when clicking "新しく会話を始める"
- ensure first prompt waits for chat creation

## Testing
- `pytest -q` *(fails: `pytest` not found)*