### PR TITLE
Add sidebar scroll top link

### DIFF
--- a/collaboration_ai_ui.html
+++ b/collaboration_ai_ui.html
@@ -150,13 +150,16 @@
     <div class="flex flex-row h-full w-full overflow-x-hidden">
 
         <div class="flex flex-col py-8 pl-6 pr-2 w-72 bg-white flex-shrink-0 shadow-lg"> 
-            <div class="flex flex-row items-center justify-center h-12 w-full">
+            <div class="flex flex-row items-center justify-center h-12 w-full" id="sidebarTop">
                 <div class="flex items-center justify-center rounded-2xl text-teal-700 bg-teal-100 h-10 w-10">
                     <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"></path>
                     </svg>
                 </div>
                 <div class="ml-2 font-bold text-2xl text-teal-700">Pale AI</div>
+            </div>
+            <div class="text-center mt-2">
+                <a href="#" id="sidebarTopLink" class="text-teal-600 underline text-sm">Topに戻る</a>
             </div>
 
             <div id="userInfoArea" class="flex flex-col items-center border border-gray-200 mt-4 w-full py-6 px-4 rounded-lg hidden">
@@ -424,6 +427,7 @@
     const chatMessagesContainer = document.getElementById('chatMessagesContainer');
     const chatSearchInput = document.getElementById('chatSearch');
     const chatSessionListDiv = document.getElementById('chatSessionList'); // ここで chatSessionListDiv を定義
+    const sidebarTopLink = document.getElementById('sidebarTopLink');
 
     const loginFormArea = document.getElementById('loginFormArea');
     const registerFormArea = document.getElementById('registerFormArea');
@@ -1849,6 +1853,14 @@ function highlightMessage(messageId) {
         populateLangSelect(talkStartOutputLang);
         updateTalkInputMode();
         toggleCharCountBox();
+
+        if (sidebarTopLink) {
+            sidebarTopLink.addEventListener('click', (e) => {
+                e.preventDefault();
+                chatSessionListDiv.scrollTo({ top: 0, behavior: 'smooth' });
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+            });
+        }
 
         if (newChatButton) {
             newChatButton.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- add a `Topに戻る` text link below the Pale AI logo
- wire up event listener to scroll sidebar and page to the top when clicked

## Testing
- `pytest -q` *(fails: `pytest` not found)*